### PR TITLE
Install python requirements and pandoc.

### DIFF
--- a/install/configure_environment.sh
+++ b/install/configure_environment.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 GIT_REPO_LIBSBP=git@github.com:swift-nav/libsbp.git
-REPO_TAG=v1.2.1 #version you want to chechout before installing 
+REPO_TAG=v1.2.1 #version you want to chechout before installing
 
 # Install libsbp in $HOME and compile it
 mkdir  ~/piksi_rtk_lib
@@ -8,9 +8,12 @@ cd ~/piksi_rtk_lib
 git clone $GIT_REPO_LIBSBP
 cd ./libsbp
 git checkout $REPO_TAG
-#sudo pip install -r requirements.txt # install dependencies only - NOT sure if it's needed
+
+# Install requirements.
+sudo apt-get install pandoc
+sudo pip install -r requirements.txt
+# Build package.
 make python
 
 # Export PYTHONPATH and make sure it points to the python subdirectory of the repository
 sh -c 'echo "export PYTHONPATH=\${PYTHONPATH}:~/piksi_rtk_lib/libsbp/python #add libsbp for RTK GPS Piksi devices" >> ~/.bashrc'
-


### PR DESCRIPTION
Tested on new 14.04 installation. Works there.

However while installing the python dependency "pyyaml==3.11" it gives the error

Found existing installation: PyYAML 3.10
    Not uninstalling PyYAML at /usr/lib/python2.7/dist-packages, owned
by OS
Running setup.py install for pyyaml
    checking if libyaml is compilable
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g
-fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/usr/include/python2.7 -c
build/temp.linux-x86_64-2.7/check_libyaml.c -o build/temp.linux-
x86_64-2.7/check_libyaml.o
    build/temp.linux-x86_64-2.7/check_libyaml.c:2:18: fatal error:
yaml.h: No such file or directory
     #include <yaml.h>
                      ^
    compilation terminated.